### PR TITLE
Update the lexer to recognize identifier names with colon

### DIFF
--- a/source/generator.c
+++ b/source/generator.c
@@ -550,7 +550,7 @@ void generateC(Generator* generator, Module* module) {
         compiler->currentFileIndex);
     
     int pathSize = jtk_CString_getSize(path);
-    uint8_t* targetFileName = allocate(unint8_t, pathSize - 3);
+    uint8_t* targetFileName = allocate(uint8_t, pathSize - 3);
     
     int32_t i;
     for (i = 0; i < pathSize - 4; i++) {

--- a/source/lexer.c
+++ b/source/lexer.c
@@ -1572,12 +1572,32 @@ Token* nextToken(Lexer* lexer) {
                 if (isIdentifierStart(lexer->la1)) {
                     /* Consume and discard the first letter. */
                     consume(lexer);
+                    
 
                     while (isIdentifierPart(lexer->la1)) {
                         /* Consume and discard the consecutive letter
                          * or digit character.
                          */
                         consume(lexer);
+                    }
+                    
+                    if (lexer->la1 == ':') {
+                        /* Consume and discard the ':' */
+                        consume(lexer);
+                        
+                         if (isIdentifierStart(lexer->la1)) {
+                            /* Consume and discard the first letter. */
+                            consume(lexer);
+                    
+
+                            while (isIdentifierPart(lexer->la1)) {
+                                /* Consume and discard the consecutive letter
+                                 * or digit character.
+                                 */
+                                consume(lexer);
+                            }
+                        }
+                        
                     }
 
                     uint8_t* text = lexer->text->m_value; // jtk_StringBuilder_toCString(lexer->text);

--- a/source/parser.c
+++ b/source/parser.c
@@ -144,40 +144,6 @@ static NewExpression* parseNewExpression(Parser* parser);
 static jtk_Pair_t* parseInitializerEntry(Parser* parser);
 static ArrayExpression* parseArrayExpression(Parser* parser);
 
-// static const char* ruleNames[] = {
-//     "module",
-//     "importDeclaration",
-//     "functionDeclaration",
-//     "block",
-//     "variableDeclaration",
-//     "breakStatement",
-//     "returnStatement",
-//     "throwStatement",
-//     "ifStatement",
-//     "iterativeStatement",
-//     "tryStatement",
-//     "structureDeclaration",
-//     "assignmentExpression",
-//     "conditionalExpression",
-//     "logicalOrExpression",
-//     "logicalAndExpression",
-//     "inclusiveOrExpression",
-//     "exclusiveOrExpression",
-//     "andExpression",
-//     "equalityExpression",
-//     "relationalExpression",
-//     "shiftExpression",
-//     "additiveExpression",
-//     "multiplicativeExpression",
-//     "unaryExpression",
-//     "postfixExpression",
-//     "subscript",
-//     "functionArguments",
-//     "memberAccess"
-//     "newExpression",
-//     "arrayExpression"
-// };
-
 #define la(parser, count) k_TokenStream_la((parser)->tokens, (count))
 #define consume(parser) consumeToken((parser)->tokens)
 #define match(parser, type) matchAndYield((parser), type)


### PR DESCRIPTION
This commit modifies the lexer so that identifier names can now include one colon.